### PR TITLE
Update nom dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "aseprite-reader"
+name = "aseprite-reader2"
 authors = ["Neikos <neikos@neikos.email>"]
 version = "0.1.0"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ resolver = "2"
 [dependencies]
 flate2 = "1.0.20"
 image = { version = "0.23.14", default-features = false }
-nom = "6.2.1"
+nom = "7.1.0"
 thiserror = "1.0.26"
 tracing = "0.1.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 name = "aseprite-reader2"
 authors = ["Neikos <neikos@neikos.email>"]
 version = "0.1.0"
+description = "Aseprite reader"
 edition = "2018"
+license = "Apache-2.0"
 resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,8 @@
 # Aseprite Reader
 
-`aseprite-reader` is a parsing crate for `.aseprite` files, made by the [Aseprite Editor](https://www.aseprite.org/).
+> ❕ Note: This, `aseprite-reader2`, is a fork of https://github.com/TheNeikos/aseprite-reader.
+
+`aseprite-reader2` is a parsing crate for `.aseprite` files, made by the [Aseprite Editor](https://www.aseprite.org/).
 
 It's focus is on speed and completeness[^1].
 

--- a/src/computed.rs
+++ b/src/computed.rs
@@ -726,7 +726,7 @@ fn image_for_frame(aseprite: &Aseprite, frame: u16) -> AseResult<RgbaImage> {
                 write_to_image(&cel, *width, *height, pixels)?;
             }
             RawAsepriteCel::Linked { frame_position } => {
-                match &layer.get_cel(*frame_position as usize - 1)?.raw_cel {
+                match &layer.get_cel(*frame_position as usize)?.raw_cel {
                     RawAsepriteCel::Raw {
                         width,
                         height,

--- a/src/computed.rs
+++ b/src/computed.rs
@@ -127,7 +127,7 @@ impl Aseprite {
                             (
                                 raw_tag.name.clone(),
                                 AsepriteTag {
-                                    frames: raw_tag.from..raw_tag.to,
+                                    frames: raw_tag.from..raw_tag.to + 1,
                                     animation_direction: raw_tag.anim_direction,
                                     name: raw_tag.name,
                                 },


### PR DESCRIPTION
This is useful for updating the memchr version used to make it more compatible with other libraries (such as Bevy).